### PR TITLE
#4 As a supporter I want to receive tokens that represent a proportional amount of my donation

### DIFF
--- a/test/CrowdFunding.t.sol
+++ b/test/CrowdFunding.t.sol
@@ -49,16 +49,21 @@ contract CrowdFundingTest is Test {
 
         // Funding the token owner
         vm.prank(tokenOwner);
-        bool success = crowdFunding.fund(amount);
+        uint256 shares = crowdFunding.fund(amount);
 
-        // Asserting on the successful transaction
-        assertTrue(success);
+        // Asserting share and amount on the successful transaction
+        assertEq(shares, amount);
 
         // GEtting the balance for the crowdFund
         uint256 crowdFundingBalance = mockERC20.balanceOf(
             address(crowdFunding)
         );
+        // asserting on balance for crowdfund
         assertEq(amount, crowdFundingBalance);
+        // Asserting on total supply of shares
+        assertEq(amount, crowdFunding.totalSupply());
+        // Asserting of total assets in vault
+        assertEq(amount, crowdFunding.totalAssets());
     }
 
     /**
@@ -77,12 +82,10 @@ contract CrowdFundingTest is Test {
         vm.expectRevert();
         crowdFunding.fund(amount);
 
-        // Getting the balance for the crowdFund
-        uint256 crowdFundingBalance = mockERC20.balanceOf(
-            address(crowdFunding)
-        );
-        // Asserting on the balance of crowdfund
-        assertEq(0, crowdFundingBalance);
+        // Asserting on the shares of crowdfund
+        assertEq(0, crowdFunding.totalSupply());
+        // Asserting on the asset of crowdfund
+        assertEq(0, crowdFunding.totalAssets());
     }
 
     /**


### PR DESCRIPTION
#4 As a supporter I want to receive tokens that represent a proportional amount of my donation
**Scope**:

Change the crowdfunding contract to be a ERC4626 and give supporters a share whenever they deposit
**Resources**:

https://docs.openzeppelin.com/contracts/5.x/erc4626
https://ethereum.org/pt/developers/docs/standards/tokens/erc-4626/
https://github.com/credbull/credbull-defi/blob/main/packages/spike-timelock/src/SimpleTokenVesting.sol
**Scenarios**:
```
Scenario: Deposit ERC20 into the Crowdfunding Campaign Contract and receive a share
    Given that I connected to the network
    And there is a Crowdfunding Campaign Contract deployed with an ERC20
    And I have a balance of 100 of the same token
    When I approve and deposit 100 into the Crowdfunding Campaign Contract
    Then the balance of the Crowdfunding Campaign Contract for that token should be 100
    And I should have received 100 shares of the Crowdfunding Campaign Contract representing my deposit
```
**Test**:

Use a MockERC20 for testing purposes