### PR TITLE
#5 As a supporter I want the owner to only be able to retrieve the funds if the campaign has achieved its target amount goal

### DIFF
--- a/src/CrowdFunding.sol
+++ b/src/CrowdFunding.sol
@@ -14,6 +14,7 @@ error TransferFailed();
 contract CrowdFunding is ERC4626, Ownable {
     // ERC20 token to be used for funding
     IERC20 public token;
+    uint256 public campaignTarget;
 
     // Mapping to track funds contributed by each supporter
     mapping(address => uint256) public funds;
@@ -21,18 +22,22 @@ contract CrowdFunding is ERC4626, Ownable {
     // Event emitted when a supporter contributes funds
     event Funded(address indexed supporter, uint256 amount);
     // Event emitted when a owner withdraws funds
-    event Withdrawl(uint256 amount);
+    event Withdrawal(uint256 amount);
 
     /**
-     * @dev Constructor to initialize the contract with a specific ERC20 token.
-     * @param _owner The owner token address to be used for withdrawing.
-     * @param _asset The IERC20 token address to be used for funding.
+     * @dev Constructor for the CrowdFundingV6 contract.
+     * @param _owner The address that will be set as the owner of the contract.
+     * @param _asset The ERC20 token to be used for the crowdfunding campaign.
+     * @param _campaignTarget The target amount of the crowdfunding campaign.
      */
     constructor(
         address _owner,
-        IERC20 _asset
+        IERC20 _asset,
+        uint256 _campaignTarget
     ) Ownable(_owner) ERC4626(_asset) ERC20("Vault Mock Token", "vMCK") {
+        // Set the ERC20 token and campaign target
         token = _asset;
+        campaignTarget = _campaignTarget;
     }
 
     /**
@@ -66,6 +71,6 @@ contract CrowdFunding is ERC4626, Ownable {
         }
 
         // Emit a Withdrawal event to log the successful withdrawal
-        emit Withdrawl(tokenBalance);
+        emit Withdrawal(tokenBalance);
     }
 }

--- a/src/MyModule.sol
+++ b/src/MyModule.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.21;
+
+import "@gnosis.pm/zodiac/contracts/core/Module.sol";
+import {ICrowdFunding} from "./interface/ICrowdFunding.sol";
+import {IERC20} from "@openzepplin/contracts/token/ERC20/IERC20.sol";
+
+// Custom error for campaign target not reached
+error CampaignTargetNotReached(uint256 tokenBalance);
+
+/**
+ * @title MyModule
+ * @dev A Gnosis Safe module for interacting with a crowdfunding campaign.
+ */
+contract MyModule is Module {
+    // Address of the crowdfunding campaign
+    address public campaign;
+
+    // Address of the ERC20 token used in the campaign
+    address public asset;
+
+    /**
+     * @dev Constructor to initialize the module.
+     * @param _owner The owner of the module.
+     * @param _campaign The address of the crowdfunding campaign.
+     * @param _asset The address of the ERC20 token used in the campaign.
+     */
+    constructor(address _owner, address _campaign, address _asset) {
+        bytes memory initializeParams = abi.encode(_owner, _campaign, _asset);
+        setUp(initializeParams);
+    }
+
+    /**
+     * @notice Initialize function, triggered when a new proxy is deployed.
+     * @dev Sets up the module with the specified parameters.
+     * @param initializeParams Parameters of initialization encoded.
+     */
+    function setUp(bytes memory initializeParams) public override initializer {
+        (address _owner, address _campaign, address _asset) = abi.decode(
+            initializeParams,
+            (address, address, address)
+        );
+
+        // Set the ERC20 token and crowdfunding campaign addresses
+        asset = _asset;
+        campaign = _campaign;
+
+        // Initialize the module
+        __Ownable_init(msg.sender);
+        setAvatar(_owner);
+        setTarget(_owner);
+        transferOwnership(_owner);
+    }
+
+    /**
+     * @notice Withdraws funds from the crowdfunding campaign.
+     * @dev Checks if the current campaign balance is greater than or equal to the target
+     *      before executing the withdrawal.
+     */
+    function withdraw() external {
+        // Get the current campaign balance and target
+        uint256 currentCampaignBalance = IERC20(asset).balanceOf(campaign);
+        uint256 campaignTarget = ICrowdFunding(campaign).campaignTarget();
+
+        // Revert if the campaign target is not reached
+        if (currentCampaignBalance < campaignTarget) {
+            revert CampaignTargetNotReached(currentCampaignBalance);
+        }
+
+        // Execute the withdrawal on the campaign
+        exec(
+            campaign,
+            0,
+            abi.encodePacked(bytes4(keccak256("withdraw()"))),
+            Enum.Operation.Call
+        );
+    }
+}

--- a/src/interface/ICrowdFunding.sol
+++ b/src/interface/ICrowdFunding.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {IERC20} from "@openzepplin/contracts/token/ERC20/IERC20.sol";
+
+interface ICrowdFunding {
+    // Events
+    event Funded(address indexed supporter, uint256 amount);
+    event Fee(address indexed platformOwner, uint256 amount);
+    event Withdrawl(uint256 amount);
+
+    // Function declarations (without implementation details)
+    function fund(uint256 amount) external returns (uint256 shares);
+
+    function withdrawTokens() external;
+
+    function maxWithdraw(address owner) external returns (uint256);
+
+    // View functions (omit the "view" keyword in interfaces)
+    function token() external returns (IERC20);
+
+    function platformOwner() external returns (address);
+
+    function feePercent() external returns (uint256);
+
+    function campaignTarget() external returns (uint256);
+
+    function expirationTime() external returns (uint256);
+}

--- a/test/mocks/MockSafe.sol
+++ b/test/mocks/MockSafe.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+/**
+ * @title MockSafe
+ * @dev A mock contract to simulate a safe that can execute transactions based on authorization.
+ */
+contract MockSafe {
+    // Address of the authorized module
+    address public module;
+
+    // Custom error for unauthorized access
+    error NotAuthorized(address unacceptedAddress);
+
+    // Fallback function to accept incoming Ether
+    receive() external payable {}
+
+    /**
+     * @notice Enables a module to perform transactions.
+     * @dev Only the owner can set the authorized module address.
+     * @param _module The address of the module to be authorized.
+     */
+    function enableModule(address _module) external {
+        // Set the authorized module address
+        module = _module;
+    }
+
+    /**
+     * @notice Executes a transaction to a specified address with a given value and data.
+     * @param to The target address of the transaction.
+     * @param value The value (in Wei) to be sent with the transaction.
+     * @param data The data payload for the transaction.
+     */
+    function exec(
+        address payable to,
+        uint256 value,
+        bytes calldata data
+    ) external {
+        // Execute the transaction and handle any revert with assembly
+        bool success;
+        bytes memory response;
+        (success, response) = to.call{value: value}(data);
+        if (!success) {
+            assembly {
+                revert(add(response, 0x20), mload(response))
+            }
+        }
+    }
+
+    /**
+     * @notice Executes a transaction from the authorized module.
+     * @dev Only the authorized module can call this function.
+     * @param to The target address of the transaction.
+     * @param value The value (in Wei) to be sent with the transaction.
+     * @param data The data payload for the transaction.
+     * @param operation The type of operation (1 for delegatecall, 0 for call).
+     * @return success A boolean indicating whether the transaction was successful.
+     */
+    function execTransactionFromModule(
+        address payable to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation
+    ) external returns (bool success) {
+        // Check if the caller is the authorized module
+        if (msg.sender != module) {
+            revert NotAuthorized(msg.sender);
+        }
+
+        // Execute the transaction based on the specified operation
+        if (operation == 1) {
+            (success, ) = to.delegatecall(data);
+        } else {
+            (success, ) = to.call{value: value}(data);
+        }
+    }
+}


### PR DESCRIPTION
#5 As a supporter I want the owner to only be able to retrieve the funds if the campaign has achieved its target amount goal

**Scope**:

Add amount goal to crowdfunding contract.
Block owners from interacting directly with the crowdfunding contract (Ownable)
Create a gnosis module to interact with the contract and force the user to only withdraw after the goal has been achieved
**Resources**:

https://github.com/gnosis/zodiac-modifier-delay
https://github.com/gnosis/zodiac
https://github.com/credbull/credbull-defi/tree/main/packages/spike-timelock
**Scenarios**:
```
Scenario: Withdraw ERC20 after Crowdfunding Campaign Contract goal has been achieved
    Given that I connected to the network
    And I am the owner of a a Crowdfunding Campaign Contract deployed with an ERC20 
    And 100 as the goal 
    And a balance of 100
    When I withdraw from the contract
    Then my balance should be 100

Scenario: Can't withdraw ERC20 before Crowdfunding Campaign Contract goal has been achieved
    Given that I connected to the network
    And I am the owner of a a Crowdfunding Campaign Contract deployed with an ERC20 
    And 100 as the goal 
    And a balance of 0
    When I withdraw from the contract
    Then my balance should be 0
    And the transaction should fail

```
**Test**:

Use a MockERC20 for testing purposes